### PR TITLE
Afinador cromático para Cuatro Venezolano (NV-002 MVP)

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,6 +33,7 @@
         >&times;</a
       >
       <a href="javascript:void(0)" id="nav-transcripciones">Transcribir</a>
+      <a href="javascript:void(0)" id="nav-afinador">Afinar</a>
     </div>
 
     <div>
@@ -44,6 +45,28 @@
     <div id="transcripts-view" style="display:none">
       <h2 class="transcripts-title">Transcripciones</h2>
       <div id="transcripts-list"></div>
+    </div>
+    <div id="tuner-view" style="display:none">
+      <h2 class="tuner-title">Afinador — Cuatro Venezolano</h2>
+
+      <div class="tuner-selectors">
+        <select id="tuner-tuning-select" aria-label="Afinación"></select>
+      </div>
+
+      <button type="button" id="tuner-start-btn" class="tuner-start-btn">
+        Iniciar afinador
+      </button>
+
+      <div id="tuner-strings" class="tuner-strings"></div>
+
+      <svg id="tuner-gauge" class="tuner-gauge" viewBox="0 0 200 110" width="240" height="140" aria-hidden="true">
+        <path class="gauge-track" d="M 10 100 A 90 90 0 0 1 190 100" fill="none" stroke-width="8" />
+        <line id="gauge-needle" class="gauge-needle" x1="100" y1="100" x2="100" y2="20" stroke-width="3" stroke-linecap="round" />
+        <circle class="gauge-pivot" cx="100" cy="100" r="6" />
+      </svg>
+
+      <div id="tuner-note-display" class="tuner-note-display">--</div>
+      <div id="tuner-freq-display" class="tuner-freq-display">0.0 Hz</div>
     </div>
     <div class="pagination-controls" id="pagination-controls">
       <button id="prev-page">&larr;</button>

--- a/src/main.js
+++ b/src/main.js
@@ -1,6 +1,7 @@
 import { recordedAudios, state, AUDIOS_PER_PAGE } from './state.js';
 import { renderPage } from './pagination.js';
 import { SetUpAudio } from './recorder.js';
+import { initTunerView } from '../tuner/tuner-ui.js';
 import './nav.js';
 
 const garbage = document.querySelector("#delete-button");
@@ -41,3 +42,4 @@ garbage.addEventListener("dragleave", () => {
 });
 
 SetUpAudio();
+initTunerView();

--- a/src/nav.js
+++ b/src/nav.js
@@ -1,8 +1,11 @@
 import { state } from './state.js';
 import { renderPage, renderTranscriptsList } from './pagination.js';
+import { showTuner, hideTuner } from '../tuner/tuner-ui.js';
 
 const audio_container = document.querySelector(".audio-container");
 const paginationControls = document.querySelector("#pagination-controls");
+const transcriptsView = document.getElementById('transcripts-view');
+const tunerView = document.getElementById('tuner-view');
 
 export function openNav() {
   document.getElementById("mySidenav").style.width = "250px";
@@ -16,19 +19,44 @@ export function closeNav() {
 window.openNav = openNav;
 window.closeNav = closeNav;
 
-document.getElementById('nav-transcripciones').addEventListener('click', () => {
-  state.transcriptsViewOpen = !state.transcriptsViewOpen;
-  const transcriptsView = document.getElementById('transcripts-view');
+// Centraliza el alternado entre vistas: oculta todas las áreas, sincroniza
+// state.transcriptsViewOpen (del que recorder.js depende) y libera el
+// afinador si se abandona su vista.
+export function showView(name) {
+  const previous = state.currentView;
+  state.currentView = name;
+  state.transcriptsViewOpen = name === 'transcripts';
 
-  if (state.transcriptsViewOpen) {
-    audio_container.style.display = 'none';
-    paginationControls.style.display = 'none';
-    transcriptsView.style.display = 'block';
-    renderTranscriptsList();
-  } else {
-    transcriptsView.style.display = 'none';
-    audio_container.style.display = 'flex';
-    renderPage();
+  audio_container.style.display = 'none';
+  paginationControls.style.display = 'none';
+  transcriptsView.style.display = 'none';
+  tunerView.style.display = 'none';
+
+  if (previous === 'tuner' && name !== 'tuner') hideTuner();
+
+  switch (name) {
+    case 'transcripts':
+      transcriptsView.style.display = 'block';
+      renderTranscriptsList();
+      break;
+    case 'tuner':
+      tunerView.style.display = 'block';
+      showTuner();
+      break;
+    case 'recorder':
+    default:
+      audio_container.style.display = 'flex';
+      renderPage();
+      break;
   }
+}
+
+document.getElementById('nav-transcripciones').addEventListener('click', () => {
+  showView(state.currentView === 'transcripts' ? 'recorder' : 'transcripts');
+  closeNav();
+});
+
+document.getElementById('nav-afinador').addEventListener('click', () => {
+  showView(state.currentView === 'tuner' ? 'recorder' : 'tuner');
   closeNav();
 });

--- a/src/state.js
+++ b/src/state.js
@@ -6,5 +6,9 @@ export const state = {
   currentPage: 1,
   draggingElement: null,
   draggingAudioIndex: null,
+  // 'recorder' | 'transcripts' | 'tuner' — fuente de verdad de la vista activa.
+  currentView: 'recorder',
+  // Derivado de currentView por showView(); se mantiene porque recorder.js
+  // lo consulta para decidir si re-renderizar la página de audios.
   transcriptsViewOpen: false,
 };

--- a/style.css
+++ b/style.css
@@ -393,3 +393,118 @@ button {
   line-height: 1.6;
   margin-top: var(--space-8);
 }
+
+/* ——— Vista del afinador ——— */
+#tuner-view {
+  width: 100%;
+  max-width: var(--audio-max-width);
+  padding-bottom: var(--space-8);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+}
+
+.tuner-title {
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-bold);
+  color: var(--color-primary);
+  margin: 0 0 var(--space-4);
+}
+
+.tuner-selectors {
+  width: 100%;
+  margin-bottom: var(--space-4);
+}
+
+#tuner-tuning-select {
+  width: 100%;
+  padding: var(--space-2) var(--space-3);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-surface);
+  color: var(--color-primary);
+  font-family: var(--font-family);
+  font-size: var(--font-size-sm);
+}
+
+.tuner-start-btn {
+  padding: var(--space-2) var(--space-6);
+  border: none;
+  border-radius: var(--radius-full);
+  background: var(--color-accent);
+  color: var(--color-surface);
+  font-family: var(--font-family);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  cursor: pointer;
+  transition: background var(--transition-fast);
+  margin-bottom: var(--space-6);
+}
+
+.tuner-start-btn:hover {
+  background: var(--color-primary);
+}
+
+.tuner-start-btn.active {
+  background: var(--color-success);
+}
+
+.tuner-strings {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: var(--space-2);
+  margin-bottom: var(--space-6);
+}
+
+.tuner-string {
+  padding: var(--space-1) var(--space-3);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-full);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-primary);
+  background: var(--color-surface);
+  transition: background var(--transition-fast), color var(--transition-fast), border-color var(--transition-fast);
+}
+
+.tuner-string.active {
+  background: var(--color-success);
+  border-color: var(--color-success);
+  color: var(--color-surface);
+}
+
+.tuner-gauge {
+  margin-bottom: var(--space-2);
+}
+
+.gauge-track {
+  stroke: var(--color-border);
+}
+
+.gauge-needle {
+  stroke: var(--color-accent);
+  transform-origin: 100px 100px;
+  transition: transform var(--transition-fast), stroke var(--transition-normal);
+}
+
+.gauge-needle.in-tune {
+  stroke: var(--color-success);
+}
+
+.gauge-pivot {
+  fill: var(--color-primary);
+}
+
+.tuner-note-display {
+  font-size: var(--font-size-xl);
+  font-weight: var(--font-weight-bold);
+  color: var(--color-primary);
+  line-height: 1.2;
+}
+
+.tuner-freq-display {
+  font-size: var(--font-size-xs);
+  color: var(--color-muted);
+}

--- a/tokens.css
+++ b/tokens.css
@@ -8,6 +8,7 @@
   --color-accent:      #c0392b;
   --color-muted:       #8c7b72;
   --color-disabled:    #bbb;
+  --color-success:     #2ecc71;
 
   /* Tipografía */
   --font-family:        'Inter', system-ui, -apple-system, sans-serif;

--- a/tuner/README.md
+++ b/tuner/README.md
@@ -1,0 +1,98 @@
+# Afinador
+
+Vista de afinador cromático, independiente del grabador, con detección de tono
+en tiempo real mediante el algoritmo MPM (McLeod Pitch Method). El alcance
+actual (MVP) cubre únicamente el **Cuatro Venezolano** (afinaciones Estándar y
+Llanero); el resto de instrumentos contemplados originalmente en el issue
+NV-002 quedó fuera de este alcance y puede agregarse incrementalmente sobre
+esta misma base — ver "Cómo agregar una nueva afinación" más abajo.
+
+## Arquitectura / pipeline de audio
+
+```
+getUserMedia({ echoCancellation: false, noiseSuppression: false, autoGainControl: false })
+  → MediaStreamSource → AnalyserNode (fftSize 8192)
+                      → AudioWorkletNode (pitch-worklet.js, buffer 4096 muestras)
+                          → postMessage → detectPitch (MPM, hilo principal)
+                              → smoothing EMA (α = 0.2) → UI
+```
+
+El `AudioContext` del afinador es un **singleton independiente** del
+`MediaRecorder` que usa el grabador (`src/recorder.js`) — ambos pipelines no se
+tocan entre sí. Nada se conecta a `destination`, para evitar realimentación
+acústica del micrófono hacia los parlantes.
+
+**Por qué el MPM corre en el hilo principal y no dentro del worklet**: el
+`AudioWorkletProcessor` corre en `AudioWorkletGlobalScope`, un hilo realtime
+donde un cálculo costoso (la NSDF del MPM es O(n²)) puede producir *glitches*
+de audio. Por eso `pitch-worklet.js` se limita a acumular muestras en un buffer
+de 4096 y enviarlas con `port.postMessage`; `pitch-detector.js` es una función
+**pura** `(buffer, sampleRate) => frequency|null` que se invoca desde el hilo
+principal (en `tuner.js`, dentro de `worklet.port.onmessage`). Esto además
+permite testear el algoritmo de forma aislada con buffers sintéticos.
+
+### Rol de cada archivo
+
+| Archivo | Responsabilidad |
+| --- | --- |
+| `pitch-detector.js` | Función pura: implementa MPM (NSDF, peak picking, interpolación parabólica). Sin DOM, sin Web Audio API. |
+| `pitch-worklet.js` | `AudioWorkletProcessor` que acumula muestras y las pasa al hilo principal. Debe cargarse como módulo separado (`audioContext.audioWorklet.addModule(...)`) — requisito de la Web Audio API. |
+| `tunings.js` | Catálogo de datos: instrumentos → variantes → cuerdas, más los helpers `freqToNote` (frecuencia → nota + cents) y `matchString` (¿esta frecuencia corresponde a esta cuerda?). |
+| `tuner.js` | Clase `Tuner`: gestiona el ciclo de vida del `AudioContext`/`AudioWorkletNode`/`getUserMedia`, aplica el suavizado EMA y expone `start()`/`stop()`. Sin DOM. |
+| `tuner-ui.js` | Capa de DOM/SVG: gauge de afinación, display de nota/frecuencia, selector de afinación, indicador de cuerdas activas. Conecta con `Tuner` y `tunings.js`. |
+
+### Ciclo de vida y liberación de recursos
+
+- `tuner.start()` solo debe invocarse de forma síncrona dentro de un gesto de
+  usuario (click en "Iniciar afinador"), nunca al navegar a la vista — los
+  navegadores (especialmente iOS Safari) bloquean la creación de
+  `AudioContext`/`getUserMedia` fuera de un user gesture.
+- `nav.js` invoca `hideTuner()` (que llama a `tuner.stop()`) cada vez que se
+  abandona la vista del afinador. `stop()` detiene los tracks del stream
+  (`stream.getTracks().forEach(t => t.stop())`, lo único que realmente libera
+  el micrófono a nivel de navegador/SO) y cierra el `AudioContext`.
+
+## Cómo agregar una nueva afinación o instrumento
+
+`tunings.js` está diseñado como un catálogo extensible. La forma de cada
+entrada de instrumento es:
+
+```js
+{
+  name: 'Nombre del instrumento',
+  variants: [
+    {
+      id: 'identificador-unico',
+      name: 'Nombre visible (p. ej. "Standard (E A D G B e)")',
+      strings: [
+        // de la cuerda más grave a la más aguda
+        { note: 'E2', freq: 82.41 },
+        // ...
+        // `altNotes` es opcional: úsalo cuando la cuerda admite más de una
+        // octava válida (cuerdas reentrantes, variación real entre instrumentos)
+        { note: 'B3', freq: 246.94, altNotes: [{ note: 'B2', freq: 123.47 }] },
+      ],
+    },
+  ],
+}
+```
+
+Pasos para agregar un nuevo instrumento:
+
+1. Define una constante hermana de `CUATRO_VENEZOLANO` con su `name` y
+   `variants`, y agrégala a `INSTRUMENTS`.
+2. **Importante**: en cuanto `INSTRUMENTS` tenga más de una entrada, hay que
+   ajustar `tuner-ui.js` para mostrar también un selector de instrumento
+   (selectores encadenados instrumento → afinación), ya que hoy — al ser MVP de
+   un solo instrumento — solo se muestra el selector de afinación
+   (`#tuner-tuning-select`, poblado directamente desde `CUATRO_VENEZOLANO.variants`).
+   Esto implica también agregar el `<select>` correspondiente en `index.html`
+   (`#tuner-view`) y los estilos asociados en `style.css`.
+3. Si el rango de frecuencias del nuevo instrumento queda fuera de
+   `MIN_FREQ`/`MAX_FREQ` definidos en `pitch-detector.js` (hoy acotados al
+   rango del Cuatro Venezolano para reducir el costo del cálculo de NSDF),
+   ajusta esas constantes para cubrirlo.
+
+No es necesario tocar `pitch-detector.js`, `pitch-worklet.js` ni `tuner.js`
+para agregar afinaciones — el algoritmo MPM y el pipeline de audio son
+independientes del catálogo de instrumentos.

--- a/tuner/pitch-detector.js
+++ b/tuner/pitch-detector.js
@@ -1,0 +1,112 @@
+// Detección de tono mediante el algoritmo MPM (McLeod Pitch Method).
+// Función pura: no toca el DOM ni APIs de audio, solo recibe un buffer de
+// muestras PCM (Float32Array, rango [-1, 1]) y la frecuencia de muestreo.
+
+// Rango de frecuencias de interés (cubre las cuerdas del Cuatro Venezolano,
+// incluyendo su octava alternativa más grave B2 ≈ 123 Hz, con margen).
+const MIN_FREQ = 70;
+const MAX_FREQ = 500;
+
+// Umbral de "paralelismo" del MPM: solo se aceptan picos cuya altura sea al
+// menos esta fracción del pico global, evitando elegir armónicos.
+const PEAK_THRESHOLD = 0.8;
+
+// Por debajo de esta claridad (altura del NSDF en el pico elegido) se
+// considera que no hay un tono predominante claro.
+const CLARITY_THRESHOLD = 0.5;
+
+// Por debajo de esta energía RMS se considera silencio/ruido de fondo.
+const RMS_THRESHOLD = 0.01;
+
+export function detectPitch(buffer, sampleRate) {
+  if (rms(buffer) < RMS_THRESHOLD) return null;
+
+  const minLag = Math.max(1, Math.floor(sampleRate / MAX_FREQ));
+  const maxLag = Math.min(buffer.length - 1, Math.ceil(sampleRate / MIN_FREQ));
+
+  const nsdf = computeNSDF(buffer, minLag, maxLag);
+  const peakIndex = pickPeak(nsdf, minLag, maxLag, PEAK_THRESHOLD);
+  if (peakIndex === -1 || nsdf[peakIndex] < CLARITY_THRESHOLD) return null;
+
+  const refinedIndex = parabolicInterpolation(nsdf, peakIndex);
+  if (refinedIndex <= 0) return null;
+
+  return sampleRate / refinedIndex;
+}
+
+function rms(buffer) {
+  let sum = 0;
+  for (let i = 0; i < buffer.length; i++) sum += buffer[i] * buffer[i];
+  return Math.sqrt(sum / buffer.length);
+}
+
+// Función de diferencia cuadrática normalizada:
+//   NSDF(τ) = 2 · ACF(τ) / [ Σ x[i]² + Σ x[i+τ]² ]   para i = 0..N-τ-1
+// Combina autocorrelación con un término de normalización de energía, lo que
+// la hace más robusta que la autocorrelación cruda frente a cambios de
+// amplitud. Solo se calcula para el rango [minLag, maxLag] de interés.
+function computeNSDF(buffer, minLag, maxLag) {
+  const n = buffer.length;
+  const nsdf = new Float32Array(maxLag + 1);
+
+  for (let lag = minLag; lag <= maxLag; lag++) {
+    let acf = 0;
+    let energy = 0;
+    for (let i = 0; i < n - lag; i++) {
+      acf += buffer[i] * buffer[i + lag];
+      energy += buffer[i] * buffer[i] + buffer[i + lag] * buffer[i + lag];
+    }
+    nsdf[lag] = energy === 0 ? 0 : (2 * acf) / energy;
+  }
+
+  return nsdf;
+}
+
+// Selección de "key maxima": recorre los lóbulos positivos del NSDF (entre
+// cruces ascendentes y descendentes por cero), guarda el máximo local de cada
+// uno, y elige el PRIMERO cuya altura supere `threshold * máximoGlobal`. Esto
+// favorece la frecuencia fundamental sobre sus armónicos (que producen picos
+// más altos pero más tarde en el eje de lags).
+function pickPeak(nsdf, minLag, maxLag, threshold) {
+  const maxima = [];
+  let i = minLag;
+
+  while (i < maxLag) {
+    // avanzar hasta un cruce ascendente por cero
+    while (i < maxLag && nsdf[i] <= 0) i++;
+
+    let maxIdx = -1;
+    while (i < maxLag && nsdf[i] > 0) {
+      if (maxIdx === -1 || nsdf[i] > nsdf[maxIdx]) maxIdx = i;
+      i++;
+    }
+    if (maxIdx !== -1) maxima.push(maxIdx);
+  }
+
+  if (maxima.length === 0) return -1;
+
+  const globalMax = Math.max(...maxima.map((idx) => nsdf[idx]));
+  const cutoff = globalMax * threshold;
+
+  for (const idx of maxima) {
+    if (nsdf[idx] >= cutoff) return idx;
+  }
+  return maxima[0];
+}
+
+// Refina el índice entero del pico a un valor sub-muestra ajustando una
+// parábola a los tres puntos vecinos (x-1, x, x+1).
+function parabolicInterpolation(nsdf, x) {
+  const x0 = x - 1;
+  const x2 = x + 1;
+  if (x0 < 0 || x2 >= nsdf.length) return x;
+
+  const s0 = nsdf[x0];
+  const s1 = nsdf[x];
+  const s2 = nsdf[x2];
+
+  const denom = s0 - 2 * s1 + s2;
+  if (denom === 0) return x;
+
+  return x + (s0 - s2) / (2 * denom);
+}

--- a/tuner/pitch-worklet.js
+++ b/tuner/pitch-worklet.js
@@ -1,0 +1,36 @@
+// AudioWorkletProcessor del afinador. Corre en el hilo de audio realtime
+// (AudioWorkletGlobalScope), por lo que debe permanecer ligero: solo acumula
+// las muestras entrantes en un buffer de tamaño fijo y, al llenarse, lo envía
+// al hilo principal vía postMessage. El cálculo de pitch (MPM, costoso) se
+// hace deliberadamente fuera de aquí, en tuner.js — ver pitch-detector.js.
+
+const BUFFER_SIZE = 4096;
+
+class PitchProcessor extends AudioWorkletProcessor {
+  constructor() {
+    super();
+    this._buffer = new Float32Array(BUFFER_SIZE);
+    this._writeIndex = 0;
+  }
+
+  process(inputs) {
+    const input = inputs[0];
+    const channel = input && input[0];
+    if (!channel) return true;
+
+    for (let i = 0; i < channel.length; i++) {
+      this._buffer[this._writeIndex++] = channel[i];
+
+      if (this._writeIndex === BUFFER_SIZE) {
+        // Copia del buffer: postMessage con transferable dejaría el array
+        // "neutered" y no podríamos seguir escribiendo en él.
+        this.port.postMessage({ buffer: this._buffer.slice(), sampleRate });
+        this._writeIndex = 0;
+      }
+    }
+
+    return true;
+  }
+}
+
+registerProcessor('pitch-processor', PitchProcessor);

--- a/tuner/tuner-ui.js
+++ b/tuner/tuner-ui.js
@@ -1,0 +1,127 @@
+// Capa de DOM/SVG del afinador. Traduce las lecturas de `Tuner` (frecuencia
+// suavizada) en la interfaz: gauge de afinación, nota detectada, selector de
+// afinación e indicador de cuerdas activas. Asume que `#tuner-view` ya existe
+// en index.html con la estructura descrita más abajo.
+
+import { Tuner } from './tuner.js';
+import { CUATRO_VENEZOLANO, freqToNote, matchString } from './tunings.js';
+
+const IN_TUNE_CENTS = 5;
+const GAUGE_RANGE_CENTS = 50;
+const GAUGE_RANGE_DEGREES = 90;
+
+let tuner = null;
+let selectedVariant = CUATRO_VENEZOLANO.variants[0];
+
+let tuningSelect;
+let startBtn;
+let stringsEl;
+let needleEl;
+let noteEl;
+let freqEl;
+
+export function initTunerView() {
+  tuningSelect = document.querySelector('#tuner-tuning-select');
+  startBtn = document.querySelector('#tuner-start-btn');
+  stringsEl = document.querySelector('#tuner-strings');
+  needleEl = document.querySelector('#gauge-needle');
+  noteEl = document.querySelector('#tuner-note-display');
+  freqEl = document.querySelector('#tuner-freq-display');
+
+  if (!tuningSelect) return; // #tuner-view no presente (por si se usa fuera de la app)
+
+  populateTuningSelect();
+  renderStrings(selectedVariant);
+
+  tuningSelect.addEventListener('change', (e) => {
+    selectedVariant = CUATRO_VENEZOLANO.variants.find((v) => v.id === e.target.value);
+    renderStrings(selectedVariant);
+  });
+
+  startBtn.addEventListener('click', handleStartStopClick);
+}
+
+// Llamado por nav.js al entrar a la vista del afinador. Deliberadamente NO
+// arranca el AudioContext: eso debe ocurrir dentro del click en "Iniciar
+// afinador" para cumplir el requisito de gesto de usuario (iOS Safari).
+export function showTuner() {}
+
+// Llamado por nav.js al salir de la vista del afinador: libera el micrófono
+// y detiene el procesamiento de audio para no dejarlo corriendo en segundo plano.
+export function hideTuner() {
+  if (tuner?.isRunning) {
+    tuner.stop();
+    setStartButtonLabel(false);
+  }
+}
+
+async function handleStartStopClick() {
+  if (!tuner) {
+    tuner = new Tuner({ onPitch: handlePitch, onError: handleTunerError });
+  }
+
+  if (tuner.isRunning) {
+    await tuner.stop();
+    setStartButtonLabel(false);
+    resetDisplays();
+  } else {
+    await tuner.start();
+    setStartButtonLabel(tuner.isRunning);
+  }
+}
+
+function handleTunerError(err) {
+  console.error('Error iniciando el afinador:', err);
+  setStartButtonLabel(false);
+  if (noteEl) noteEl.textContent = 'Sin acceso al micrófono';
+}
+
+function setStartButtonLabel(running) {
+  startBtn.textContent = running ? 'Detener afinador' : 'Iniciar afinador';
+  startBtn.classList.toggle('active', running);
+}
+
+function resetDisplays() {
+  noteEl.textContent = '--';
+  freqEl.textContent = '0.0 Hz';
+  updateGauge(0);
+  highlightActiveString(null);
+}
+
+function handlePitch({ frequency, rawFrequency }) {
+  const { name, cents } = freqToNote(frequency);
+  noteEl.textContent = name;
+  freqEl.textContent = `${rawFrequency.toFixed(1)} Hz`;
+  updateGauge(cents);
+  highlightActiveString(frequency);
+}
+
+function updateGauge(cents) {
+  const clamped = Math.max(-GAUGE_RANGE_CENTS, Math.min(GAUGE_RANGE_CENTS, cents));
+  const angle = (clamped / GAUGE_RANGE_CENTS) * GAUGE_RANGE_DEGREES;
+  needleEl.style.transform = `rotate(${angle}deg)`;
+  needleEl.classList.toggle('in-tune', Math.abs(cents) <= IN_TUNE_CENTS);
+}
+
+function populateTuningSelect() {
+  tuningSelect.innerHTML = CUATRO_VENEZOLANO.variants
+    .map((variant) => `<option value="${variant.id}">${variant.name}</option>`)
+    .join('');
+  tuningSelect.value = selectedVariant.id;
+}
+
+function renderStrings(variant) {
+  stringsEl.innerHTML = variant.strings
+    .map((s, index) => `<span class="tuner-string" data-index="${index}">${s.note}</span>`)
+    .join('');
+}
+
+function highlightActiveString(detectedFreq) {
+  const chips = stringsEl.querySelectorAll('.tuner-string');
+  const activeIndex =
+    detectedFreq != null
+      ? selectedVariant.strings.findIndex((s) => matchString(detectedFreq, s))
+      : -1;
+
+  chips.forEach((chip, index) => chip.classList.toggle('active', index === activeIndex));
+}

--- a/tuner/tuner.js
+++ b/tuner/tuner.js
@@ -1,0 +1,104 @@
+// Motor de audio del afinador: gestiona su propio AudioContext, completamente
+// independiente del MediaRecorder usado por el grabador (src/recorder.js).
+// No toca el DOM — eso es responsabilidad de tuner-ui.js.
+
+import { detectPitch } from './pitch-detector.js';
+
+const SMOOTHING_ALPHA = 0.2;
+
+export class Tuner {
+  constructor({ onPitch, onError } = {}) {
+    this._onPitch = onPitch;
+    this._onError = onError;
+
+    this._ctx = null;
+    this._stream = null;
+    this._source = null;
+    this._analyser = null;
+    this._worklet = null;
+    this._smoothedFreq = null;
+    this._running = false;
+  }
+
+  get isRunning() {
+    return this._running;
+  }
+
+  // Debe invocarse de forma síncrona dentro de un gesto de usuario (click):
+  // los navegadores (en particular iOS Safari) bloquean la creación/arranque
+  // de AudioContext y getUserMedia fuera de un user gesture.
+  async start() {
+    if (this._running) return;
+
+    try {
+      this._ctx = new AudioContext();
+
+      this._stream = await navigator.mediaDevices.getUserMedia({
+        audio: {
+          echoCancellation: false,
+          noiseSuppression: false,
+          autoGainControl: false,
+        },
+      });
+
+      this._source = this._ctx.createMediaStreamSource(this._stream);
+
+      this._analyser = this._ctx.createAnalyser();
+      this._analyser.fftSize = 8192;
+
+      await this._ctx.audioWorklet.addModule(new URL('./pitch-worklet.js', import.meta.url));
+      this._worklet = new AudioWorkletNode(this._ctx, 'pitch-processor');
+      this._worklet.port.onmessage = (event) => this._handleWorkletMessage(event.data);
+
+      // Conectados solo entre sí: NUNCA a `destination`, para no producir
+      // realimentación acústica del micrófono hacia los parlantes.
+      this._source.connect(this._analyser);
+      this._source.connect(this._worklet);
+
+      this._smoothedFreq = null;
+      this._running = true;
+    } catch (err) {
+      await this.stop();
+      this._onError?.(err);
+    }
+  }
+
+  // Idempotente: libera micrófono, nodos y AudioContext. Seguro de llamar
+  // sin haber arrancado o más de una vez (p. ej. al cambiar de vista).
+  async stop() {
+    if (this._worklet) {
+      this._worklet.port.onmessage = null;
+      this._worklet.disconnect();
+    }
+    this._analyser?.disconnect();
+    this._source?.disconnect();
+
+    // Detener los tracks es lo que realmente libera el micrófono a nivel de
+    // navegador/SO — cerrar el AudioContext por sí solo no basta.
+    this._stream?.getTracks().forEach((track) => track.stop());
+
+    if (this._ctx && this._ctx.state !== 'closed') {
+      await this._ctx.close();
+    }
+
+    this._ctx = null;
+    this._stream = null;
+    this._source = null;
+    this._analyser = null;
+    this._worklet = null;
+    this._smoothedFreq = null;
+    this._running = false;
+  }
+
+  _handleWorkletMessage({ buffer, sampleRate }) {
+    const rawFrequency = detectPitch(buffer, sampleRate);
+    if (!rawFrequency) return;
+
+    this._smoothedFreq =
+      this._smoothedFreq == null
+        ? rawFrequency
+        : SMOOTHING_ALPHA * rawFrequency + (1 - SMOOTHING_ALPHA) * this._smoothedFreq;
+
+    this._onPitch?.({ frequency: this._smoothedFreq, rawFrequency });
+  }
+}

--- a/tuner/tunings.js
+++ b/tuner/tunings.js
@@ -1,0 +1,68 @@
+// Catálogo de afinaciones del afinador.
+//
+// Forma de cada entrada de instrumento:
+//   { name: string, variants: Variant[] }
+// Variant:
+//   { id: string, name: string, strings: StringDef[] }
+// StringDef (de la cuerda más grave a la más aguda):
+//   { note: string, freq: number, altNotes?: { note: string, freq: number }[] }
+//
+// - `note`/`freq`: nota científica y frecuencia de referencia (A4 = 440 Hz) de la cuerda.
+// - `altNotes`: octavas alternativas igualmente válidas para esa cuerda. Úsalo cuando el
+//   instrumento tiene cuerdas reentrantes o variación real de octava entre ejemplares
+//   (p. ej. el Cuatro Venezolano: su cuerda B suena como B3 o como B2 según el cuatro).
+//
+// Para agregar un nuevo instrumento: añade una entrada hermana de CUATRO_VENEZOLANO con
+// su propio `name` y `variants`, y regístrala en INSTRUMENTS. Si pasas a tener más de
+// un instrumento, ajusta tuner-ui.js para mostrar también un selector de instrumento
+// (hoy, al ser MVP de un solo instrumento, solo se muestra el selector de afinación).
+
+export const CUATRO_VENEZOLANO = {
+  name: 'Cuatro Venezolano',
+  variants: [
+    {
+      id: 'estandar',
+      name: 'Estándar (B E A D)',
+      strings: [
+        { note: 'B3', freq: 246.94, altNotes: [{ note: 'B2', freq: 123.47 }] },
+        { note: 'E3', freq: 164.81 },
+        { note: 'A3', freq: 220.00 },
+        { note: 'D4', freq: 293.66 },
+      ],
+    },
+    {
+      id: 'llanero',
+      name: 'Llanero (A D F# B)',
+      strings: [
+        { note: 'A3', freq: 220.00 },
+        { note: 'D4', freq: 293.66 },
+        { note: 'F#4', freq: 369.99 },
+        { note: 'B3', freq: 246.94 },
+      ],
+    },
+  ],
+};
+
+export const INSTRUMENTS = [CUATRO_VENEZOLANO];
+
+const NOTE_NAMES = ['C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 'B'];
+
+// Convierte una frecuencia detectada a la nota científica más cercana y su
+// desviación en cents respecto a esa nota (afinación estándar A4 = 440 Hz).
+export function freqToNote(freq) {
+  const midi = 69 + 12 * Math.log2(freq / 440);
+  const rounded = Math.round(midi);
+  const cents = Math.round((midi - rounded) * 100);
+  const name = NOTE_NAMES[((rounded % 12) + 12) % 12];
+  const octave = Math.floor(rounded / 12) - 1;
+  return { name: `${name}${octave}`, cents, midi: rounded };
+}
+
+const MATCH_TOLERANCE_HZ = 15;
+
+// Indica si una frecuencia detectada corresponde a la cuerda dada, comparando
+// tanto contra su frecuencia principal como contra sus octavas alternativas.
+export function matchString(detectedFreq, stringDef) {
+  const candidates = [{ freq: stringDef.freq }, ...(stringDef.altNotes ?? [])];
+  return candidates.some((c) => Math.abs(c.freq - detectedFreq) <= MATCH_TOLERANCE_HZ);
+}


### PR DESCRIPTION
## Resumen

- Agrega una nueva vista de afinador cromático, completamente independiente del grabador, con detección de pitch en tiempo real (algoritmo MPM) implementada vía AudioWorklet.
- Alcance MVP: soporta el **Cuatro Venezolano** (afinaciones Estándar B-E-A-D y Llanero A-D-F#-B), incluyendo el manejo de octavas alternativas para sus cuerdas graves. El resto de instrumentos del issue original queda fuera de este alcance — la base de datos/UI quedó documentada para extenderse incrementalmente (ver `tuner/README.md`).
- Integra la nueva vista al sidenav (enlace "Afinar") mediante una función `showView(name)` centralizada en `src/nav.js`, sin modificar `src/recorder.js` ni romper el flujo existente de transcripciones.

## Cierra

Closes #5

## Plan de pruebas

- [ ] Sidenav → "Afinar" abre la vista del afinador
- [ ] Tocar una cuerda del Cuatro detecta la nota correctamente
- [ ] Cambiar afinación (Estándar/Llanero) actualiza las cuerdas mostradas
- [ ] Octava alternativa (B2/B3) de la cuerda grave del Cuatro estándar se reconoce como válida
- [ ] Al salir de la vista del afinador se libera el micrófono (indicador del navegador se apaga)
- [ ] El grabador (grabar, reproducir, transcribir, paginar) sigue funcionando sin regresiones

🤖 Generated with [Claude Code](https://claude.com/claude-code)